### PR TITLE
Adds support for path completion for unix paths

### DIFF
--- a/book/src/editor.md
+++ b/book/src/editor.md
@@ -32,6 +32,7 @@
 | `cursorcolumn` | Highlight all columns with a cursor | `false` |
 | `gutters` | Gutters to display: Available are `diagnostics` and `diff` and `line-numbers` and `spacer`, note that `diagnostics` also includes other features like breakpoints, 1-width padding will be inserted if gutters is non-empty | `["diagnostics", "spacer", "line-numbers", "spacer", "diff"]` |
 | `auto-completion` | Enable automatic pop up of auto-completion | `true` |
+| `path-completion` | Enable filepath completion. Show files and directories if an existing path at the cursor was recognized, either absolute or relative to the current opened document or current working directory (if the buffer is not yet saved). Defaults to true. | `true` |
 | `auto-format` | Enable automatic formatting on save | `true` |
 | `idle-timeout` | Time in milliseconds since last keypress before idle timers trigger. | `250` |
 | `completion-timeout` | Time in milliseconds after typing a word character before completions are shown, set to 5 for instant.  | `250` |

--- a/book/src/generated/typable-cmd.md
+++ b/book/src/generated/typable-cmd.md
@@ -2,7 +2,7 @@
 | --- | --- |
 | `:quit`, `:q` | Close the current view. |
 | `:quit!`, `:q!` | Force close the current view, ignoring unsaved changes. |
-| `:open`, `:o` | Open a file from disk into the current view. |
+| `:open`, `:o`, `:edit`, `:e` | Open a file from disk into the current view. |
 | `:buffer-close`, `:bc`, `:bclose` | Close the current buffer. |
 | `:buffer-close!`, `:bc!`, `:bclose!` | Close the current buffer forcefully, ignoring unsaved changes. |
 | `:buffer-close-others`, `:bco`, `:bcloseother` | Close all buffers but the currently focused one. |

--- a/book/src/languages.md
+++ b/book/src/languages.md
@@ -69,6 +69,7 @@ These configuration keys are available:
 | `formatter`           | The formatter for the language, it will take precedence over the lsp when defined. The formatter must be able to take the original file as input from stdin and write the formatted file to stdout |
 | `soft-wrap` | [editor.softwrap](./configuration.md#editorsoft-wrap-section)
 | `text-width`          |  Maximum line length. Used for the `:reflow` command and soft-wrapping if `soft-wrap.wrap-at-text-width` is set, defaults to `editor.text-width`   |
+| `path-completion`     | Overrides the `editor.path-completion` config key for the language. |
 | `workspace-lsp-roots`     | Directories relative to the workspace root that are treated as LSP roots. Should only be set in `.helix/config.toml`. Overwrites the setting of the same name in `config.toml` if set. |
 | `persistent-diagnostic-sources` | An array of LSP diagnostic sources assumed unchanged when the language server resends the same set of diagnostics. Helix can track the position for these diagnostics internally instead. Useful for diagnostics that are recomputed on save.
 

--- a/helix-core/src/syntax.rs
+++ b/helix-core/src/syntax.rs
@@ -125,6 +125,9 @@ pub struct LanguageConfiguration {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub formatter: Option<FormatterConfiguration>,
 
+    /// If set, overrides `editor.path-completion`.
+    pub path_completion: Option<bool>,
+
     #[serde(default)]
     pub diagnostic_severity: Severity,
 

--- a/helix-term/src/handlers/completion/resolve.rs
+++ b/helix-term/src/handlers/completion/resolve.rs
@@ -9,6 +9,7 @@ use helix_view::Editor;
 
 use crate::handlers::completion::CompletionItem;
 use crate::job;
+use crate::ui::CompletionItemSource;
 
 /// A hook for resolving incomplete completion items.
 ///
@@ -42,6 +43,11 @@ impl ResolveHandler {
         if item.resolved {
             return;
         }
+
+        let CompletionItemSource::LanguageServer(ls_id) = item.provider else {
+            return;
+        };
+
         // We consider an item to be fully resolved if it has non-empty, none-`None` details,
         // docs and additional text-edits. Ideally we could use `is_some` instead of this
         // check but some language servers send values like `Some([])` for additional text
@@ -72,7 +78,7 @@ impl ResolveHandler {
         if self.last_request.as_deref().is_some_and(|it| it == item) {
             return;
         }
-        let Some(ls) = editor.language_servers.get_by_id(item.provider).cloned() else {
+        let Some(ls) = editor.language_servers.get_by_id(ls_id).cloned() else {
             item.resolved = true;
             return;
         };

--- a/helix-term/src/ui/mod.rs
+++ b/helix-term/src/ui/mod.rs
@@ -17,7 +17,7 @@ mod text_decorations;
 use crate::compositor::Compositor;
 use crate::filter_picker_entry;
 use crate::job::{self, Callback};
-pub use completion::{Completion, CompletionItem};
+pub use completion::{Completion, CompletionItem, CompletionItemSource};
 pub use editor::EditorView;
 use helix_stdx::rope;
 pub use markdown::Markdown;

--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -1638,6 +1638,12 @@ impl Document {
         self.version
     }
 
+    pub fn supports_path_completion(&self) -> bool {
+        self.language_config()
+            .and_then(|lang_config| lang_config.path_completion)
+            .unwrap_or_else(|| self.config.load().path_completion)
+    }
+
     /// maintains the order as configured in the language_servers TOML array
     pub fn language_servers(&self) -> impl Iterator<Item = &helix_lsp::Client> {
         self.language_config().into_iter().flat_map(move |config| {

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -269,6 +269,11 @@ pub struct Config {
     pub auto_pairs: AutoPairConfig,
     /// Automatic auto-completion, automatically pop up without user trigger. Defaults to true.
     pub auto_completion: bool,
+    /// Enable filepath completion.
+    /// Show files and directories if an existing path at the cursor was recognized,
+    /// either absolute or relative to the current opened document or current working directory (if the buffer is not yet saved).
+    /// Defaults to true.
+    pub path_completion: bool,
     /// Automatic formatting on save. Defaults to true.
     pub auto_format: bool,
     /// Automatic save on focus lost and/or after delay.
@@ -946,6 +951,7 @@ impl Default for Config {
             middle_click_paste: true,
             auto_pairs: AutoPairConfig::default(),
             auto_completion: true,
+            path_completion: true,
             auto_format: true,
             auto_save: AutoSave::default(),
             idle_timeout: Duration::from_millis(250),


### PR DESCRIPTION
* Autocompletion is triggered with `/`.
* Documentation preview (file type, file permissions, canonicalized full path).
* Home-path resolution (`~/path`)
* Link resolution (makes sense for preview, since the LSP specification (`CompletionItemKind`) only supports files and folders but not symlinks)
* Async (via `spawn_blocking` instead of tokios file accessor functions, as they IMHO make the code less readable and are quite a bit slower than just spawning a "thread")
* Configurable with `editor.path-completion` (default `true`), per-language overrideable path-completion support
* Adds a new enum field `source` to `ui::CompletionItem` (that might be extended, with more completion sources)